### PR TITLE
Fix the on board reset button

### DIFF
--- a/upython/ttboard/pins/gpio_map.py
+++ b/upython/ttboard/pins/gpio_map.py
@@ -94,6 +94,13 @@ class GPIOMap:
             # 'rp_projclk', -- don't do this during "safe" operation
             'ctrl_ena'
         ]
+    
+    @classmethod
+    def default_pull(cls, pin):
+        if pin in ["nproject_rst", "ctrl_ena"]:
+            return Pin.PULL_UP
+        return Pin.PULL_DOWN
+    
     @classmethod 
     def all(cls):
         retDict = {

--- a/upython/ttboard/pins/pins.py
+++ b/upython/ttboard/pins/pins.py
@@ -227,7 +227,7 @@ class Pins:
         for name,gpio in GPIOMap.all().items():
             if name == self.muxName:
                 continue
-            p = StandardPin(name, gpio, Pin.IN, pull=Pin.PULL_DOWN)
+            p = StandardPin(name, gpio, Pin.IN, pull=GPIOMap.default_pull(name))
             setattr(self, f'pin_{name}', p.raw_pin)
             setattr(self, name, p) # self._pinFunc(p)) 
             self._allpins[name] = p

--- a/upython/ttboard/pins/standard.py
+++ b/upython/ttboard/pins/standard.py
@@ -61,7 +61,7 @@ class StandardPin:
     def mode(self, setMode:int):
         self._mode = setMode 
         log.debug(f'Setting pin {self.name} to {self.mode_str}')
-        self.raw_pin.init(setMode)
+        self.raw_pin.init(setMode, pull=self._pull)
         
     @property 
     def mode_str(self):


### PR DESCRIPTION
Because the project reset was pulled down by default, the reset would stay low after the button was pressed.

I've also switch ctrl_ena to pull up by default, as that seems likely to lead to fewer accidental resets.