### PR TITLE
Support disabling/reenabling PWM project clock

### DIFF
--- a/upython/ttboard/demoboard.py
+++ b/upython/ttboard/demoboard.py
@@ -182,13 +182,10 @@ class DemoBoard:
         '''
             Start an automatic clock for the selected project (using
             PWM).
-            @param freqHz: The frequency of the clocking, in Hz
+            @param freqHz: The frequency of the clocking, in Hz, or 0 to disable PWM
             @param duty_u16: Optional duty cycle (0-0xffff), defaults to 50%  
         '''
-        self.clockProjectPWMStop()
-        if freqHz < 1: # equiv to stop 
-            return 
-        self._clock_pwm = self.project_clk.pwm(freqHz, duty_u16)
+        self._clock_pwm = self.pins.rp_projclk.pwm(freqHz, duty_u16)
         return self._clock_pwm
     
     def clockProjectPWMStop(self):
@@ -199,12 +196,8 @@ class DemoBoard:
         if self._clock_pwm is None:
             return 
         
-        self._clock_pwm.deinit()
-        self._clock_pwm = None
+        self.clockProjectPWM(0)
         
-        # Set pin back to a normal output
-        self.project_clk.pwm(0)
-
 
     def applyUserConfig(self, design:Design):
         

--- a/upython/ttboard/demoboard.py
+++ b/upython/ttboard/demoboard.py
@@ -201,8 +201,11 @@ class DemoBoard:
         
         self._clock_pwm.deinit()
         self._clock_pwm = None
-    
-    
+        
+        # Set pin back to a normal output
+        self.project_clk.pwm(0)
+
+
     def applyUserConfig(self, design:Design):
         
         log.debug(f'Design "{design.name}" loaded, apply user conf')

--- a/upython/ttboard/pins/standard.py
+++ b/upython/ttboard/pins/standard.py
@@ -99,6 +99,7 @@ class StandardPin:
         if freq is not None and freq < 1:
             log.info(f'Disabling pwm on {self.name}')
             self.mode = Pin.OUT
+            self._pwm = None
             return
         
         log.debug(f"Setting PWM on {self.name} to {freq}Hz")

--- a/upython/ttboard/pins/standard.py
+++ b/upython/ttboard/pins/standard.py
@@ -98,9 +98,11 @@ class StandardPin:
         
         if freq is not None and freq < 1:
             log.info(f'Disabling pwm on {self.name}')
+            if self._pwm is not None:
+                self._pwm.deinit()
+                self._pwm = None
             self.mode = Pin.OUT
-            self._pwm = None
-            return
+            return None
         
         log.debug(f"Setting PWM on {self.name} to {freq}Hz")
         if self._pwm is None:


### PR DESCRIPTION
This allows you to use `tt.clockProjectOnce()` after you did a `tt.clockProjectPWMStop()`, and then restart the PWM clock again with `tt.clockProjectPWM()`